### PR TITLE
Minor syntax fix for const and let keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Take a look at how this pattern may be applied in the table below.
 | `getPostData` | | `get` | `Post` | `Data` |
 | `handleClickOutside` | | `handle` | `Click` | `Outside` |
 | `shouldDisplayMessage` | `should` | `Display` | `Message`| |
-| `canAllowAnonymousUser` | `can` | `Allow` | `Anonymous`| `User` |
+| `allowsAnonymousUser` | | `allows` | `Anonymous`| `User` |
 
 > **Note:** The order of context affects the meaning of a variable. For example, `shouldUpdateComponent` means *you* are about to update a component, while `shouldComponentUpdate` tells you that *component* will update on itself, and you are but controlling whether it should do that right now.
 In other words, **high context emphasizes the meaning of a variable**.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Take a look at how this pattern may be applied in the table below.
 | `getPostData` | | `get` | `Post` | `Data` |
 | `handleClickOutside` | | `handle` | `Click` | `Outside` |
 | `shouldDisplayMessage` | `should` | `Display` | `Message`| |
+| `canAllowAnonymousUser` | `can` | `Allow` | `Anonymous`| `User` |
 
 > **Note:** The order of context affects the meaning of a variable. For example, `shouldUpdateComponent` means *you* are about to update a component, while `shouldComponentUpdate` tells you that *component* will update on itself, and you are but controlling whether it should do that right now.
 In other words, **high context emphasizes the meaning of a variable**.
@@ -131,7 +132,7 @@ function getFruitsCount() {
 Declaratively sets a variable with value `A` to value `B`.
 
 ```js
-const fruits = 0
+let fruits = 0
 
 function setFruits(nextFruits) {
   fruits = nextFruits
@@ -147,7 +148,8 @@ Sets a variable back to its initial value or state.
 
 ```js
 const initialFruits = 5
-const fruits = initialFruits
+let fruits = initialFruits
+
 setFruits(10)
 console.log(fruits) // 10
 

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -74,6 +74,7 @@ return (<Button disabled={isDisabled} />);
 | `getPostData` | | `get` | `Post` | `Data` |
 | `handleClickOutside` | | `handle` | `Click` | `Outside` |
 | `shouldDisplayMessage` | `should` | `Display` | `Message`| |
+| `canAllowAnonymousUser` | `can` | `Allow` | `Anonymous`| `User` |
 
 ## Наименование методов
 
@@ -98,7 +99,7 @@ function fetchPosts(postCount) {
 #### `set`
 Декларативно присвоить переменной `variableA` со значением `valueA` значение `valueB`.
 ```js
-const fruits = 0;
+let fruits = 0;
 
 function setFruits(nextFruits) {
   fruits = nextFruits;
@@ -111,7 +112,8 @@ setFruits(5); // fruits === 5
 Вернуть чему-то его первоначальное значение.
 ```js
 const initialFruits = 5;
-const fruits = initialFruits;
+let fruits = initialFruits;
+
 setFruits(10); // fruits === 10
 
 function resetFruits() {

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -74,7 +74,7 @@ return (<Button disabled={isDisabled} />);
 | `getPostData` | | `get` | `Post` | `Data` |
 | `handleClickOutside` | | `handle` | `Click` | `Outside` |
 | `shouldDisplayMessage` | `should` | `Display` | `Message`| |
-| `canAllowAnonymousUser` | `can` | `Allow` | `Anonymous`| `User` |
+| `allowsAnonymousUser` | | `allows` | `Anonymous`| `User` |
 
 ## Наименование методов
 


### PR DESCRIPTION
Corrections to the use of "const" and "let" keywords in the examples.