### PR TITLE
Refactor: Change template literal to normal string concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Creates new data from the existing one. Mostly applicable to strings, objects, o
 
 ```js
 function composePageUrl(pageName, pageId) {
-  return `${pageName.toLowerCase()}-${pageId}`
+  return (pageName.toLowerCase() + '-' + pageId)
 }
 ```
 


### PR DESCRIPTION
Great cheatsheet! Just a minor opinion on making this repository more language agnostic. 

I thought many developers who are unaware of the template literal syntax of JavaScript, might be confused by this piece of code [here](https://github.com/kettanaito/naming-cheatsheet#compose). I felt simple string concatenation would be a more _generally understood_ way to deliver the example.

P.S. I am aware there are many JavaScript-only features like arrow functions but I feel they do not contribute directly to the understanding of the specific topic.