### PR TITLE
Minor typos and adds a missing link to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ function getFruitsCount() {
 
 ### `set`
 
-Sets a declarative variable, with value `A` to value `B`.
+Sets a variable in a declarative way, with value `A` to value `B`.
 
 ```js
 const fruits = 0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [Avoid contractions](#avoid-contractions)
 - [Avoid context duplication](#avoid-context-duplication)
 - [Reflect expected result](#reflect-expected-result)
-- Naming functions
+- [Naming functions](#naming-functions)
   - [A/HC/LC pattern](#ahclc-pattern)
     - [Actions](#actions)
     - [Context](#context)
@@ -146,7 +146,7 @@ function getFruitsCount() {
 
 ### `set`
 
-Declaratively sets a variable with value `A` to value `B`.
+Sets a declarative variable, with value `A` to value `B`.
 
 ```js
 const fruits = 0
@@ -206,7 +206,7 @@ removeFilter('price', selectedFilters)
 
 ### `delete`
 
-Completely erazes something from the realms of existence.
+Completely erases something from the realms of existence.
 
 Imagine you are a content editor, and there is that notorious post you wish to get rid of. Once you clicked a shiny "Delete post" button, the CMS performed a `deletePost` action, **not** `removePost`.
 


### PR DESCRIPTION
Hi @kettanaito,

Thank you very much for this nice repo, really great guidelines and recommendations!

Reading through the document I found some typos and a missing link I thought to add.
- Correction of the word erases in the `delete` section
- Change `Declaratively` to `in a declarative way` 
- Add a link to the Naming Functions section in the table of contents

Feel free to give me any feedback you seem appropiate.

Best regards!