### PR TITLE
Changed Named convention's bad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Pick **one** naming convention and follow it. It may be `camelCase`, or `snake_c
 
 ```js
 /* Bad */
-const pages_count = 5
+const page_count = 5
 const shouldUpdate = true
 
 /* Good */


### PR DESCRIPTION
I changed pages_count to page_count because it seems more right. Also all 3 examples have same variable. It showed the result better.