### PR TITLE
Fixed Order of Arguments In Context Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ function filter(predicate, list) {
 
 /* Function operating exactly on posts */
 function getRecentPosts(posts) {
-  return filter(posts, (post) => post.date === Date.now())
+  return filter((post) => post.date === Date.now(), posts)
 }
 ```
 


### PR DESCRIPTION
Swapped the arguments in the example code of the Context section so that the predicate and collection are in proper order.

Inspired by the wise observations of #43 Thank you y'all for recognizing the error and proposing a fix! Please feel free to disregard this comment if the original reporter of the issue wishes to propose a PR.