### PR TITLE
Adjust prefix copy to account for predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,32 @@
 
 # Naming cheatsheet
 
-- [English language](#english-language)
-- [Naming convention](#naming-convention)
-- [S-I-D](#s-i-d)
-- [Avoid contractions](#avoid-contractions)
-- [Avoid context duplication](#avoid-context-duplication)
-- [Reflect the expected result](#reflect-the-expected-result)
+- [Naming cheatsheet](#naming-cheatsheet)
+  - [English language](#english-language)
+  - [Naming convention](#naming-convention)
+  - [S-I-D](#s-i-d)
+  - [Avoid contractions](#avoid-contractions)
+  - [Avoid context duplication](#avoid-context-duplication)
+  - [Reflect the expected result](#reflect-the-expected-result)
 - [Naming functions](#naming-functions)
-  - [A/HC/LC pattern](#ahclc-pattern)
-    - [Actions](#actions)
-    - [Context](#context)
-    - [Prefixes](#prefixes)
-- [Singular and Plurals](#singular-and-plurals)
+  - [A/HC/LC Pattern](#ahclc-pattern)
+  - [Actions](#actions)
+    - [`get`](#get)
+    - [`set`](#set)
+    - [`reset`](#reset)
+    - [`fetch`](#fetch)
+    - [`remove`](#remove)
+    - [`delete`](#delete)
+    - [`compose`](#compose)
+    - [`handle`](#handle)
+  - [Context](#context)
+  - [Prefixes](#prefixes)
+    - [`is`](#is)
+    - [`has`](#has)
+    - [`should`](#should)
+    - [`min`/`max`](#minmax)
+    - [`prev`/`next`](#prevnext)
+  - [Singular and Plurals](#singular-and-plurals)
 
 ---
 
@@ -285,7 +299,7 @@ function getRecentPosts(posts) {
 
 ## Prefixes
 
-Prefix enhances the meaning of a variable. It is rarely used in function names.
+A prefix enhances the meaning of a variable. They are rarely used in function names, unless the given function is a [predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates.
 
 ### `is`
 


### PR DESCRIPTION
Was reviewing this, and though it'd make sense to add that it's common to see predicates like `isSomeKnownType()` :tada: 