### PR TITLE
Change asynchronous get to fetch suggestion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ function getFruitCount() {
 
 > See also [compose](#compose).
 
-You can use `get` when performing asynchronous operations as well:
+You can use `fetch` when performing asynchronous operations as well:
 
 ```js
-async function getUser(id) {
+async function fetchUser(id) {
   const user = await fetch(`/api/user/${id}`)
   return user
 }

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ function getFruitCount() {
 
 > See also [compose](#compose).
 
+### `fetch`
+
 You can use `fetch` when performing asynchronous operations as well:
 
 ```js


### PR DESCRIPTION
In the example displayed currently in the notes, it suggests that the asynchronous function would return instantaneously when it could return errors or throw. In my opinion, it would be better to recommend a namespace in which would reflect that accordingly.

_The current example:_
>  You can use `get` when performing asynchronous operations as well:
```js
async function getUser(id) {
  const user = await fetch(`/api/user/${id}`)
  return user
}
```

_The proposed change:_
> ### `fetch`
> You can use `fetch` when performing asynchronous operations as well:
```js
async function fetchUser(id) {
  const user = await fetch(`/api/user/${id}`)
  return user
}
```

The ideaology behind my suggestion is as follows. When you're playing **fetch** with a dog, the dog does not always immediately return. The dog may get distracted or while returning drop it before returning to the handler, thus erroring out and dropping the return. 

