### PR TITLE
docs: fix GitHub capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const friends = ['Kate', 'John']
 
 ## Naming convention
 
-Pick **one** naming convention and follow it. It may be `camelCase`, `PascalCase`, `snake_case`, or anything else, as long as it remains consistent. Many programming languages have their own traditions regarding naming conventions; check the documentation for your language or study some popular repositories on Github!
+Pick **one** naming convention and follow it. It may be `camelCase`, `PascalCase`, `snake_case`, or anything else, as long as it remains consistent. Many programming languages have their own traditions regarding naming conventions; check the documentation for your language or study some popular repositories on GitHub!
 
 ```js
 /* Bad */


### PR DESCRIPTION
With this PR Docs have been updated 

docs update => proper capitalisation would be better. 👍


### Other information:
Signed-off-by: Ayushman Singh Chauhan <ascb508@gmail.com>